### PR TITLE
`session_finished()` callback raises exception in case that the plugin is installed but no `--junit-file` argument was given

### DIFF
--- a/src/balderplugin/junit/plugin.py
+++ b/src/balderplugin/junit/plugin.py
@@ -48,8 +48,9 @@ class JunitPlugin(balder.BalderPlugin):
         return test_case
 
     def session_finished(self, executor_tree: Union[ExecutorTree, None]):
-        filepath = pathlib.Path(self.balder_session.parsed_args.junit_file)
-        if executor_tree is not None and filepath is not None:
+        filepath_str = self.balder_session.parsed_args.junit_file
+        if executor_tree is not None and filepath_str is not None:
+            filepath = pathlib.Path(filepath_str)
             all_test_suites = []
             for cur_setup_executor in executor_tree.setup_executors:
                 for cur_scenario_executor in cur_setup_executor.scenario_executors:


### PR DESCRIPTION
This PR fixes a bug in the plugin. If the plugin is installed, but no `--junit-file` argument is given, the value for the argument is None. The implementation of `session_finished()` didn't check this and tried a direct conversion of this argument into a `pathlib.Path`. This resulted into an error.