### PR TITLE
fix(plugin.py): use methods `get_*_executors()` instead of properties `*_executors`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ project_urls =
 packages =
     balderplugin.junit
 install_requires =
-    baldertest>=0.1.0b3
+    baldertest>=0.1.0b7
     junit-xml>=1.9
 python_requires = >=3.9
 package_dir =

--- a/src/balderplugin/junit/plugin.py
+++ b/src/balderplugin/junit/plugin.py
@@ -52,11 +52,11 @@ class JunitPlugin(balder.BalderPlugin):
         if executor_tree is not None and filepath_str is not None:
             filepath = pathlib.Path(filepath_str)
             all_test_suites = []
-            for cur_setup_executor in executor_tree.setup_executors:
-                for cur_scenario_executor in cur_setup_executor.scenario_executors:
-                    for cur_variation_executor in cur_scenario_executor.variation_executors:
+            for cur_setup_executor in executor_tree.get_setup_executors():
+                for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
+                    for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                         all_testcases = []
-                        for cur_test_case_executor in cur_variation_executor.testcase_executors:
+                        for cur_test_case_executor in cur_variation_executor.get_testcase_executors():
                             test_case = self.create_test_case(cur_test_case_executor)
                             all_testcases.append(test_case)
 


### PR DESCRIPTION
In a recent balder version update this has changed.